### PR TITLE
update: upgrade llm to 0.2.0-dev

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,19 @@
 version = 3
 
 [[package]]
-name = "ahash"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8fd72866655d1904d6b0997d0b07ba561047d070fbe29de039031c641b61217"
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fc08ce920c31afb70f013dcce1bfc3a3195de6a228474e45e1f145b36f8d04"
 dependencies = [
  "memchr",
 ]
@@ -341,27 +344,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "csv"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
-dependencies = [
- "csv-core",
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "csv-core"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2466559f260f48ad25fe6317b3c8dac77b5bdb5763ac7d9d6103530663bc90"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "ctor"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -620,8 +602,8 @@ dependencies = [
 
 [[package]]
 name = "ggml"
-version = "0.1.1"
-source = "git+https://github.com/rustformers/llm.git?branch=main#f523cbf4616bde571bfa21284b917a7bf8b20d9d"
+version = "0.2.0-dev"
+source = "git+https://github.com/rustformers/llm.git?branch=main#a5b9365a57c23dffa543a1c07416add160fd0b0a"
 dependencies = [
  "ggml-sys",
  "thiserror",
@@ -629,8 +611,8 @@ dependencies = [
 
 [[package]]
 name = "ggml-sys"
-version = "0.1.1"
-source = "git+https://github.com/rustformers/llm.git?branch=main#f523cbf4616bde571bfa21284b917a7bf8b20d9d"
+version = "0.2.0-dev"
+source = "git+https://github.com/rustformers/llm.git?branch=main#a5b9365a57c23dffa543a1c07416add160fd0b0a"
 dependencies = [
  "cc",
 ]
@@ -648,16 +630,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02b4af3693f1b705df946e9fe5631932443781d0aabb423b62fcd4d73f6d2fd0"
 dependencies = [
  "crunchy",
-]
-
-[[package]]
-name = "hashbrown"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96282e96bfcd3da0d3aa9938bedf1e50df3269b6db08b4876d2da0bb1a0841cf"
-dependencies = [
- "ahash",
- "autocfg",
 ]
 
 [[package]]
@@ -862,22 +834,23 @@ dependencies = [
 
 [[package]]
 name = "llm"
-version = "0.1.1"
-source = "git+https://github.com/rustformers/llm.git?branch=main#f523cbf4616bde571bfa21284b917a7bf8b20d9d"
+version = "0.2.0-dev"
+source = "git+https://github.com/rustformers/llm.git?branch=main#a5b9365a57c23dffa543a1c07416add160fd0b0a"
 dependencies = [
  "llm-base",
  "llm-bloom",
  "llm-gpt2",
  "llm-gptj",
+ "llm-gptneox",
  "llm-llama",
- "llm-neox",
+ "llm-mpt",
  "serde",
 ]
 
 [[package]]
 name = "llm-base"
-version = "0.1.1"
-source = "git+https://github.com/rustformers/llm.git?branch=main#f523cbf4616bde571bfa21284b917a7bf8b20d9d"
+version = "0.2.0-dev"
+source = "git+https://github.com/rustformers/llm.git?branch=main#a5b9365a57c23dffa543a1c07416add160fd0b0a"
 dependencies = [
  "bytemuck",
  "ggml",
@@ -885,6 +858,7 @@ dependencies = [
  "memmap2",
  "partial_sort",
  "rand",
+ "regex",
  "serde",
  "serde_bytes",
  "thiserror",
@@ -892,8 +866,8 @@ dependencies = [
 
 [[package]]
 name = "llm-bloom"
-version = "0.1.1"
-source = "git+https://github.com/rustformers/llm.git?branch=main#f523cbf4616bde571bfa21284b917a7bf8b20d9d"
+version = "0.2.0-dev"
+source = "git+https://github.com/rustformers/llm.git?branch=main#a5b9365a57c23dffa543a1c07416add160fd0b0a"
 dependencies = [
  "bytemuck",
  "llm-base",
@@ -901,8 +875,8 @@ dependencies = [
 
 [[package]]
 name = "llm-gpt2"
-version = "0.1.1"
-source = "git+https://github.com/rustformers/llm.git?branch=main#f523cbf4616bde571bfa21284b917a7bf8b20d9d"
+version = "0.2.0-dev"
+source = "git+https://github.com/rustformers/llm.git?branch=main#a5b9365a57c23dffa543a1c07416add160fd0b0a"
 dependencies = [
  "bytemuck",
  "llm-base",
@@ -910,36 +884,41 @@ dependencies = [
 
 [[package]]
 name = "llm-gptj"
-version = "0.1.1"
-source = "git+https://github.com/rustformers/llm.git?branch=main#f523cbf4616bde571bfa21284b917a7bf8b20d9d"
+version = "0.2.0-dev"
+source = "git+https://github.com/rustformers/llm.git?branch=main#a5b9365a57c23dffa543a1c07416add160fd0b0a"
 dependencies = [
  "bytemuck",
  "llm-base",
+]
+
+[[package]]
+name = "llm-gptneox"
+version = "0.2.0-dev"
+source = "git+https://github.com/rustformers/llm.git?branch=main#a5b9365a57c23dffa543a1c07416add160fd0b0a"
+dependencies = [
+ "bytemuck",
+ "llm-base",
+ "serde",
 ]
 
 [[package]]
 name = "llm-llama"
-version = "0.1.1"
-source = "git+https://github.com/rustformers/llm.git?branch=main#f523cbf4616bde571bfa21284b917a7bf8b20d9d"
+version = "0.2.0-dev"
+source = "git+https://github.com/rustformers/llm.git?branch=main#a5b9365a57c23dffa543a1c07416add160fd0b0a"
 dependencies = [
  "bytemuck",
  "llm-base",
- "protobuf",
  "rand",
- "rust_tokenizers",
- "serde",
- "serde_json",
  "thiserror",
 ]
 
 [[package]]
-name = "llm-neox"
-version = "0.1.1"
-source = "git+https://github.com/rustformers/llm.git?branch=main#f523cbf4616bde571bfa21284b917a7bf8b20d9d"
+name = "llm-mpt"
+version = "0.2.0-dev"
+source = "git+https://github.com/rustformers/llm.git?branch=main#a5b9365a57c23dffa543a1c07416add160fd0b0a"
 dependencies = [
  "bytemuck",
  "llm-base",
- "serde",
 ]
 
 [[package]]
@@ -1299,12 +1278,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "protobuf"
-version = "2.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e86d370532557ae7573551a1ec8235a0f8d6cb276c7c9e6aa490b511c447485"
-
-[[package]]
 name = "quote"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1404,13 +1377,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.7.3"
+version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1f693b24f6ac912f4893ef08244d70b6067480d2f1a46e950c9691e6749d1d"
+checksum = "81ca098a9821bd52d6b24fd8b10bd081f47d39c22778cafaa75a2857a62c6390"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 1.0.1",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.7.2",
 ]
 
 [[package]]
@@ -1420,23 +1393,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
-name = "rust_tokenizers"
-version = "3.1.6"
+name = "regex-syntax"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c4313059ea8764ff2743ffaaa42fba0e4d5f8ff12febe4f3c74d598f629f62"
-dependencies = [
- "csv",
- "hashbrown",
- "itertools 0.8.2",
- "lazy_static",
- "protobuf",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "unicode-normalization",
- "unicode-normalization-alignments",
-]
+checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
 
 [[package]]
 name = "rustc-hash"
@@ -1682,27 +1642,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87cc5ceb3875bb20c2890005a4e226a4651264a5c75edb2421b52861a0a0cb50"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokenizers"
 version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5cf49017523bf0bc01c9966f172c5f120bbb7b96cccd1708772dd42e767fb9f5"
 dependencies = [
- "aho-corasick",
+ "aho-corasick 0.7.20",
  "clap",
  "derive_builder",
  "esaxx-rs",
@@ -1720,7 +1665,7 @@ dependencies = [
  "rayon",
  "rayon-cond",
  "regex",
- "regex-syntax",
+ "regex-syntax 0.6.29",
  "serde",
  "serde_json",
  "spm_precompiled",
@@ -1765,15 +1710,6 @@ name = "unicode-ident"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
-
-[[package]]
-name = "unicode-normalization"
-version = "0.1.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
-dependencies = [
- "tinyvec",
-]
 
 [[package]]
 name = "unicode-normalization-alignments"

--- a/packages/core/index.d.ts
+++ b/packages/core/index.d.ts
@@ -8,7 +8,8 @@ export const enum ModelType {
   Bloom = 'Bloom',
   Gpt2 = 'Gpt2',
   GptJ = 'GptJ',
-  NeoX = 'NeoX'
+  GptNeoX = 'GptNeoX',
+  Mpt = 'Mpt'
 }
 export interface InferenceToken {
   token: string

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -70,6 +70,7 @@ pub async fn convert(path: String, _element_type: ElementType) -> Result<()> {
     let handle = tokio::task::spawn_blocking(move || {
         let path = Path::new(path.as_str());
         println!("path: {:?}", path);
+        // convert_pth_to_ggml is removed from llm
         // convert_pth_to_ggml(path, element_type.into());
     })
     .await;

--- a/packages/core/src/lib.rs
+++ b/packages/core/src/lib.rs
@@ -11,7 +11,7 @@ mod types;
 use std::{path::Path, sync::Arc};
 
 use context::LLMContext;
-use llm::{models::llama::convert::convert_pth_to_ggml, InferenceFeedback};
+use llm::InferenceFeedback;
 use tokio::sync::Mutex;
 use types::{Generate, InferenceResult, ModelLoad};
 
@@ -48,29 +48,29 @@ pub enum ElementType {
     MostlyQ5_1,
 }
 
-impl From<ElementType> for llm::FileType {
+impl From<ElementType> for llm::FileTypeFormat {
     fn from(element_type: ElementType) -> Self {
         match element_type {
-            ElementType::F32 => llm::FileType::F32,
-            ElementType::MostlyF16 => llm::FileType::MostlyF16,
-            ElementType::MostlyQ4_0 => llm::FileType::MostlyQ4_0,
-            ElementType::MostlyQ4_1 => llm::FileType::MostlyQ4_1,
-            ElementType::MostlyQ4_1SomeF16 => llm::FileType::MostlyQ4_1SomeF16,
-            ElementType::MostlyQ4_2 => llm::FileType::MostlyQ4_2,
-            ElementType::MostlyQ8_0 => llm::FileType::MostlyQ8_0,
-            ElementType::MostlyQ5_0 => llm::FileType::MostlyQ5_0,
-            ElementType::MostlyQ5_1 => llm::FileType::MostlyQ5_1,
+            ElementType::F32 => llm::FileTypeFormat::F32,
+            ElementType::MostlyF16 => llm::FileTypeFormat::MostlyF16,
+            ElementType::MostlyQ4_0 => llm::FileTypeFormat::MostlyQ4_0,
+            ElementType::MostlyQ4_1 => llm::FileTypeFormat::MostlyQ4_1,
+            ElementType::MostlyQ4_1SomeF16 => llm::FileTypeFormat::MostlyQ4_1SomeF16,
+            ElementType::MostlyQ4_2 => llm::FileTypeFormat::MostlyQ4_2,
+            ElementType::MostlyQ8_0 => llm::FileTypeFormat::MostlyQ8_0,
+            ElementType::MostlyQ5_0 => llm::FileTypeFormat::MostlyQ5_0,
+            ElementType::MostlyQ5_1 => llm::FileTypeFormat::MostlyQ5_1,
         }
     }
 }
 
 /// Not implemented yet.
 #[napi(js_name = "convert")]
-pub async fn convert(path: String, element_type: ElementType) -> Result<()> {
+pub async fn convert(path: String, _element_type: ElementType) -> Result<()> {
     let handle = tokio::task::spawn_blocking(move || {
         let path = Path::new(path.as_str());
         println!("path: {:?}", path);
-        convert_pth_to_ggml(path, element_type.into());
+        // convert_pth_to_ggml(path, element_type.into());
     })
     .await;
     match handle {

--- a/packages/core/src/load.rs
+++ b/packages/core/src/load.rs
@@ -6,11 +6,11 @@ use llm::{load, LoadProgress, Model, ModelParameters};
 
 impl ModelLoad {
     pub fn load<M: llm::KnownModel + 'static>(&self) -> Result<Box<dyn Model>, napi::Error> {
+        let default_params: ModelParameters = Default::default();
         let params = ModelParameters {
-            prefer_mmap: self.use_mmap.unwrap_or(true),
-            context_size: self.num_ctx_tokens.unwrap_or(2048) as usize,
-            lora_adapters: self.lora_path.as_ref().map(|path| vec![path.into()]),
-            ..Default::default()
+            prefer_mmap: self.use_mmap.unwrap_or(default_params.prefer_mmap),
+            context_size: self.num_ctx_tokens.unwrap_or(default_params.context_size as i64) as usize,
+            lora_adapters: self.lora_path.as_ref().map(|path| vec![path.into()]).or(default_params.lora_adapters),
         };
 
         let path = Path::new(&self.model_path);

--- a/packages/core/src/load.rs
+++ b/packages/core/src/load.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use crate::types::ModelLoad;
 use anyhow::Result;
@@ -8,8 +8,8 @@ impl ModelLoad {
     pub fn load<M: llm::KnownModel + 'static>(&self) -> Result<Box<dyn Model>, napi::Error> {
         let params = ModelParameters {
             prefer_mmap: self.use_mmap.unwrap_or(true),
-            n_context_tokens: self.num_ctx_tokens.unwrap_or(2048) as usize,
-            lora_adapter: self.lora_path.as_ref().map(PathBuf::from),
+            context_size: self.num_ctx_tokens.unwrap_or(2048) as usize,
+            lora_adapters: self.lora_path.as_ref().map(|path| vec![path.into()]),
             ..Default::default()
         };
 
@@ -57,7 +57,7 @@ impl ModelLoad {
                     )
                 );
             }
-            LoadProgress::LoraApplied { name } => {
+            LoadProgress::LoraApplied { name, source: _ } => {
                 log::info!("Applied Lora: {}", name);
             }
         })

--- a/packages/core/src/types.rs
+++ b/packages/core/src/types.rs
@@ -9,7 +9,8 @@ pub enum ModelType {
     Bloom,
     Gpt2,
     GptJ,
-    NeoX,
+    GptNeoX,
+    Mpt
 }
 
 #[napi(object)]


### PR DESCRIPTION
This PR updates the version of LLM to 0.2.0-dev (at https://github.com/rustformers/llm/tree/a5b9365a57c23dffa543a1c07416add160fd0b0a). It also adds MPT to the list of model types.

I must admit that I'm very new to this project (and even Rust). Please feel free to apply your own changes on top of this branch.

Looks like `convert_pth_to_ggml` is removed from `llm` and I have no idea what to do here:

https://github.com/Atome-FE/llama-node/pull/86/files#diff-734e579940800965103740299b6c251cccc5e2c08e6d172b582feb6babd1a66fR73